### PR TITLE
fix(#89): cicd 파이프라인에서 ec2의 불필요한 도커이미지 삭제 명령을 추가

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -135,4 +135,5 @@ jobs:
             aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
             docker compose down
             docker compose pull
+            docker image prune -af
             docker compose up -d


### PR DESCRIPTION
## 🎯PR Summary
<!---- PR 유형을 체크해주세요 -->
[ PR Type ]
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<!---- 코드 변경 사유 및 목적 설명을 작성해주세요 -->

## 📄 Changes Made
- 사용하지 않는 도커 이미지를 EC2에 쌓이는 것을 방지하기 위해, EC2에 쌓인 불필요한 도커 이미지를 삭제하는 명령어를 파이프라인에 추가했습니다.

## 🙋🏻‍ Review Point

## PR Checklist
<!----  PR이 다음 요구 사항을 충족하는지 확인하세요. -->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)

## 🔗 Reference
- close #89 
