### PR TITLE
fix(#157): 단건 조회에 대한 캐시 삭제 

### DIFF
--- a/review/src/main/java/com/ticketing/review/application/service/ReviewService.java
+++ b/review/src/main/java/com/ticketing/review/application/service/ReviewService.java
@@ -24,7 +24,6 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
@@ -98,9 +97,11 @@ public class ReviewService {
    * @return
    */
   @Transactional(readOnly = false)
-  @CachePut(cacheNames = "reviewCache", key = "#result.reviewId", cacheManager = "reviewCacheManager")
-  @CacheEvict(cacheNames = {
-      "reviewSearchCache"}, allEntries = true, cacheManager = "reviewCacheManager")
+  @Caching(evict = {
+      @CacheEvict(cacheNames = "reviewCache", key = "#reviewId", cacheManager = "reviewCacheManager"),
+      @CacheEvict(cacheNames = {
+          "reviewSearchCache"}, allEntries = true, cacheManager = "reviewCacheManager")
+  })
   public UpdateReviewResponseDto updateReview(UUID reviewId, UpdateReviewRequestDto requestDto) {
     //DB에 reviewId에 대한 정보가 존재하는지 확인
     Review findReview = reviewRepository.findById(reviewId).orElseThrow(
@@ -130,7 +131,7 @@ public class ReviewService {
    */
   @Transactional(readOnly = false)
   @Caching(evict = {
-      @CacheEvict(cacheNames = "reviewCache", key = "args[0]", cacheManager = "reviewCacheManager"),
+      @CacheEvict(cacheNames = "reviewCache", key = "#reviewId", cacheManager = "reviewCacheManager"),
       @CacheEvict(cacheNames = {
           "reviewSearchCache"}, allEntries = true, cacheManager = "reviewCacheManager")
   })
@@ -158,7 +159,7 @@ public class ReviewService {
    * @return
    */
   @Transactional(readOnly = true)
-  @Cacheable(cacheNames = "reviewCache", key = "args[0]", cacheManager = "reviewCacheManager")
+  @Cacheable(cacheNames = "reviewCache", key = "#reviewId", cacheManager = "reviewCacheManager")
   public ReviewResponseDto getReview(UUID reviewId) {
     Review findReview = reviewRepository.findById(reviewId).orElseThrow(
         () -> new ReviewException(ErrorCode.REVIEW_NOT_FOUND)


### PR DESCRIPTION
## 🎯PR Summary
<!---- PR 유형을 체크해주세요 -->
[ PR Type ]
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<!---- 코드 변경 사유 및 목적 설명을 작성해주세요 -->

## 📄 Changes Made
<!---- 구현 내용 설명 -->
Update 후 Review 단건 조회 시 에러 발생
Update 후 CachePut이 아닌 CacheEvit을 통해 캐시에 올라와 있는 리뷰 정보 삭제하는 방향으로 수정 

## 🙋🏻‍ Review Point
<!----  리뷰어가 확인해야 할 사항 -->
- 사이드 이펙트 여부 확인 부탁 드립니다. 

## PR Checklist
<!----  PR이 다음 요구 사항을 충족하는지 확인하세요. -->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)

## 🔗 Reference

- Issue #157 
